### PR TITLE
feat: add parameter file and SSE API key support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ ENV/
 
 # OS
 .DS_Store
+
+# Config
+params.json

--- a/README.md
+++ b/README.md
@@ -60,6 +60,30 @@ config = BridgeConfig(
 )
 ```
 
+#### Using `mcp-proxy` over SSE
+
+When connecting through an HTTP proxy that exposes an MCP server via Server-Sent Events, provide the proxy URL and optional API key instead of `mcp_server_params`:
+
+```python
+config = BridgeConfig(
+    llm_config=LLMConfig(
+        api_key=os.getenv("OPENAI_API_KEY"),
+        model=os.getenv("OPENAI_MODEL", "gpt-4o"),
+        base_url=None,
+    ),
+    mcp_sse_url="http://localhost:3000/sse",
+    mcp_sse_api_key="your-mcp-api-key"
+)
+```
+
+#### Parameter File
+
+Configuration can also be supplied via a JSON parameter file. Copy `params.example.json` to `params.json`, adjust values for your LLM (e.g. LM Studio), MCP settings, and system prompt, then run:
+
+```bash
+python -m mcp_llm_bridge.main --params params.json
+```
+
 ### Additional Endpoint Support
 
 The bridge also works with any endpoint implementing the OpenAI API specification:
@@ -91,7 +115,7 @@ I didn't test this, but it should work.
 ## Usage
 
 ```bash
-python -m mcp_llm_bridge.main
+python -m mcp_llm_bridge.main --params params.json
 
 # Try: "What are the most expensive products in the database?"
 # Exit with 'quit' or Ctrl+C

--- a/params.example.json
+++ b/params.example.json
@@ -1,0 +1,17 @@
+{
+  "llm_config": {
+    "api_key": "not-needed",
+    "model": "local-model",
+    "base_url": "http://localhost:1234/v1",
+    "temperature": 0.7,
+    "max_tokens": 2000
+  },
+  "mcp_server_params": {
+    "command": "uvx",
+    "args": ["mcp-server-sqlite", "--db-path", "test.db"],
+    "env": null
+  },
+  "mcp_sse_url": "http://localhost:3000/sse",
+  "mcp_sse_api_key": "your-mcp-api-key",
+  "system_prompt": "You are a helpful assistant that can use tools."
+}

--- a/src/mcp_llm_bridge/bridge.py
+++ b/src/mcp_llm_bridge/bridge.py
@@ -36,7 +36,14 @@ class MCPLLMBridge:
     
     def __init__(self, config: BridgeConfig):
         self.config = config
-        self.mcp_client = MCPClient(config.mcp_server_params)
+        headers = (
+            {"Authorization": f"Bearer {config.mcp_sse_api_key}"}
+            if config.mcp_sse_api_key
+            else None
+        )
+        self.mcp_client = MCPClient(
+            config.mcp_server_params, config.mcp_sse_url, headers
+        )
         self.llm_client = LLMClient(config.llm_config)
         self.query_tool = DatabaseQueryTool("test.db")  # Initialize database query tool
         

--- a/src/mcp_llm_bridge/config.py
+++ b/src/mcp_llm_bridge/config.py
@@ -15,6 +15,8 @@ class LLMConfig:
 @dataclass
 class BridgeConfig:
     """Configuration for the MCP-LLM Bridge"""
-    mcp_server_params: StdioServerParameters
     llm_config: LLMConfig
+    mcp_server_params: Optional[StdioServerParameters] = None
+    mcp_sse_url: Optional[str] = None
+    mcp_sse_api_key: Optional[str] = None
     system_prompt: Optional[str] = None

--- a/tests/test_mcp_client.py
+++ b/tests/test_mcp_client.py
@@ -1,0 +1,22 @@
+import pytest
+from unittest.mock import AsyncMock, patch
+from mcp_llm_bridge.mcp_client import MCPClient
+
+
+@pytest.mark.asyncio
+async def test_sse_connection_used_with_headers():
+    mock_ctx = AsyncMock()
+    mock_ctx.__aenter__.return_value = ("r", "w")
+    session_ctx = AsyncMock()
+    session_obj = AsyncMock()
+    session_ctx.__aenter__.return_value = session_obj
+    session_obj.initialize = AsyncMock()
+
+    headers = {"Authorization": "Bearer test-key"}
+    with patch("mcp_llm_bridge.mcp_client.sse_client", return_value=mock_ctx) as sse_mock, \
+         patch("mcp_llm_bridge.mcp_client.ClientSession", return_value=session_ctx):
+        client = MCPClient(sse_url="http://example.com/sse", sse_headers=headers)
+        await client.connect()
+        sse_mock.assert_called_once_with("http://example.com/sse", headers=headers)
+        session_obj.initialize.assert_awaited()
+        assert client.session is session_obj


### PR DESCRIPTION
## Summary
- allow SSE connections to include an API key via `mcp_sse_api_key`
- support loading bridge configuration from a JSON parameter file
- document parameter file usage and SSE authentication

## Testing
- ❌ `pip install -e .[test]` (failed: Could not find a version that satisfies the requirement setuptools>=45)
- ✅ `PYTHONPATH=src python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6427e2f888323bdb2d15381a4a471