### PR TITLE
Load BridgeConfig from params.json file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,3 @@ ENV/
 .DS_Store
 
 # Config
-params.json

--- a/params.json
+++ b/params.json
@@ -1,0 +1,17 @@
+{
+  "llm_config": {
+    "api_key": "not-needed",
+    "model": "local-model",
+    "base_url": "http://localhost:1234/v1",
+    "temperature": 0.7,
+    "max_tokens": 2000
+  },
+  "mcp_server_params": {
+    "command": "uvx",
+    "args": ["mcp-server-sqlite", "--db-path", "test.db"],
+    "env": null
+  },
+  "mcp_sse_url": "http://localhost:3000/sse",
+  "mcp_sse_api_key": "your-mcp-api-key",
+  "system_prompt": "You are a helpful assistant that can use tools."
+}

--- a/src/mcp_llm_bridge/config.py
+++ b/src/mcp_llm_bridge/config.py
@@ -1,4 +1,5 @@
 # src/mcp_llm_bridge/config.py
+import json
 from dataclasses import dataclass
 from typing import Optional
 from mcp import StdioServerParameters
@@ -20,3 +21,27 @@ class BridgeConfig:
     mcp_sse_url: Optional[str] = None
     mcp_sse_api_key: Optional[str] = None
     system_prompt: Optional[str] = None
+
+    @classmethod
+    def from_dict(cls, data: dict) -> "BridgeConfig":
+        """Create a BridgeConfig from a dictionary."""
+        llm_cfg = LLMConfig(**data["llm_config"])
+
+        server_params = None
+        if data.get("mcp_server_params"):
+            server_params = StdioServerParameters(**data["mcp_server_params"])
+
+        return cls(
+            llm_config=llm_cfg,
+            mcp_server_params=server_params,
+            mcp_sse_url=data.get("mcp_sse_url"),
+            mcp_sse_api_key=data.get("mcp_sse_api_key"),
+            system_prompt=data.get("system_prompt"),
+        )
+
+    @classmethod
+    def from_file(cls, path: str) -> "BridgeConfig":
+        """Load configuration from a JSON file."""
+        with open(path) as f:
+            data = json.load(f)
+        return cls.from_dict(data)

--- a/src/mcp_llm_bridge/main.py
+++ b/src/mcp_llm_bridge/main.py
@@ -1,10 +1,8 @@
 # src/mcp_llm_bridge/main.py
 import asyncio
-import json
 import argparse
 from dotenv import load_dotenv
-from mcp import StdioServerParameters
-from mcp_llm_bridge.config import BridgeConfig, LLMConfig
+from mcp_llm_bridge.config import BridgeConfig
 from mcp_llm_bridge.bridge import BridgeManager
 import colorlog
 import logging
@@ -43,22 +41,7 @@ async def main():
     load_dotenv()
 
     # Load configuration from parameter file
-    with open(args.params) as f:
-        params = json.load(f)
-
-    llm_cfg = LLMConfig(**params["llm_config"])
-
-    server_params = None
-    if params.get("mcp_server_params"):
-        server_params = StdioServerParameters(**params["mcp_server_params"])
-
-    config = BridgeConfig(
-        llm_config=llm_cfg,
-        mcp_server_params=server_params,
-        mcp_sse_url=params.get("mcp_sse_url"),
-        mcp_sse_api_key=params.get("mcp_sse_api_key"),
-        system_prompt=params.get("system_prompt"),
-    )
+    config = BridgeConfig.from_file(args.params)
 
     logger.info(f"Starting bridge with model: {config.llm_config.model}")
     


### PR DESCRIPTION
## Summary
- add `params.json` config file for LLM and MCP parameters
- allow `BridgeConfig` to be built from JSON via new helpers
- use `BridgeConfig.from_file` in `main.py`

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6468208c88323a5b5dc2b36fd80c7