### PR TITLE
Handle missing choices from LLM completions

### DIFF
--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,0 +1,15 @@
+import pytest
+from types import SimpleNamespace
+from mcp_llm_bridge.llm_client import LLMResponse
+
+
+def test_llm_response_missing_choices():
+    completion = SimpleNamespace(choices=None)
+    with pytest.raises(ValueError):
+        LLMResponse(completion)
+
+
+def test_llm_response_empty_choices():
+    completion = SimpleNamespace(choices=[])
+    with pytest.raises(ValueError):
+        LLMResponse(completion)


### PR DESCRIPTION
## Summary
- prevent crashes when LLM completion lacks choices by validating response
- add tests covering missing or empty LLM choices

## Testing
- `PYTHONPATH=src pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c64994305c832390d6d45bbd4d9c43