### PR TITLE
Allow flexible config JSON parsing

### DIFF
--- a/src/mcp_llm_bridge/config.py
+++ b/src/mcp_llm_bridge/config.py
@@ -42,6 +42,10 @@ class BridgeConfig:
     @classmethod
     def from_file(cls, path: str) -> "BridgeConfig":
         """Load configuration from a JSON file."""
-        with open(path) as f:
-            data = json.load(f)
+        with open(path, encoding="utf-8") as f:
+            raw = f.read()
+        try:
+            data = json.loads(raw, strict=False)
+        except json.JSONDecodeError as exc:
+            raise ValueError(f"Invalid JSON configuration in {path}: {exc}") from exc
         return cls.from_dict(data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,10 @@
+from mcp_llm_bridge.config import BridgeConfig
+
+
+def test_from_file_allows_unescaped_newlines(tmp_path):
+    params = """{"llm_config": {"api_key": "k", "model": "m"}, "system_prompt": "Line1
+Line2"}"""
+    path = tmp_path / "params.json"
+    path.write_text(params)
+    cfg = BridgeConfig.from_file(str(path))
+    assert cfg.system_prompt == "Line1\nLine2"


### PR DESCRIPTION
## Summary
- allow JSON config with unescaped control characters by using `json.loads(..., strict=False)`
- add unit test ensuring params containing raw newlines parse correctly

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c64bafa42c832392e9d93d580ae72f