### PR TITLE
Allow flexible config JSON parsing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "aiohttp>=3.8.0",
     "typing-extensions>=4.0.0",
     "colorlog>=6.9.0",
+    "json5>=0.9",
 ]
 
 [tool.poetry]
@@ -36,6 +37,7 @@ asyncio = ">=3.4.3"
 aiohttp = ">=3.8.0"
 typing-extensions = ">=4.0.0"
 colorlog = ">=6.9.0"
+json5 = ">=0.9"
 
 [project.optional-dependencies]
 test = [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,25 @@
+from mcp_llm_bridge.config import BridgeConfig
+
+
+def test_from_file_allows_unescaped_newlines(tmp_path):
+    params = """{"llm_config": {"api_key": "k", "model": "m"}, "system_prompt": "Line1
+Line2"}"""
+    path = tmp_path / "params.json"
+    path.write_text(params)
+    cfg = BridgeConfig.from_file(str(path))
+    assert cfg.system_prompt == "Line1\nLine2"
+
+
+def test_from_file_handles_comments_and_trailing_commas(tmp_path):
+    params = """
+    {
+      // comment before object
+      "llm_config": {"api_key": "k", "model": "m",},
+      "system_prompt": "hi", // comment after value
+    }
+    """
+    path = tmp_path / "params.json"
+    path.write_text(params)
+    cfg = BridgeConfig.from_file(str(path))
+    assert cfg.llm_config.model == "m"
+    assert cfg.system_prompt == "hi"


### PR DESCRIPTION
## Summary
- allow JSON config with comments, trailing commas, and unescaped control characters using `json5` fallback
- add unit test covering JSON with comments and trailing commas
- declare `json5` as dependency

## Testing
- `PYTHONPATH=src pytest -q`
- `PYTHONPATH=src python -m mcp_llm_bridge.main --params params.json` *(fails: `httpx.ConnectError`)*

------
https://chatgpt.com/codex/tasks/task_e_68c64bafa42c832392e9d93d580ae72f